### PR TITLE
Correctly handles timestamp input.

### DIFF
--- a/havoc
+++ b/havoc
@@ -163,7 +163,7 @@ while getopts "acd:e:p:r:su:" flag; do
             
             # Prompt for user input.  Use default value if nothing provided.
             read -p "${parameter} [${default_value}]: " user_response < /dev/tty
-            if [ ! ${user_response} ]; then
+            if [[ -z ${user_response} ]]; then
               echo "${line}" >> ${playbookini}
             else
               echo "${parameter} = ${user_response}" >> ${playbookini}


### PR DESCRIPTION
Playbooks with an .ini file which request a timestamp in `mm-dd-YYYY HH:MM:SS` format would present a "Unary operator expected" error.  The error seems to be cosmetic, but can be confusing to users who are unaware.  This patch handles the input correctly.

Will also submit a separate pull request in havocsh/havoc-playbooks to correct the `activity_report.ini.sample` file to reflect the timestamp format as the "default" option to reduce confusion.